### PR TITLE
Changed multirun output folder to have unique id

### DIFF
--- a/microsim-core/src/main/java/microsim/data/ExperimentManager.java
+++ b/microsim-core/src/main/java/microsim/data/ExperimentManager.java
@@ -176,7 +176,8 @@ public class ExperimentManager {
 			}
 		}
 		else{
-			 DatabaseUtils.databaseInputUrl = experiment.inputFolder + File.separator + "input";
+//			 DatabaseUtils.databaseInputUrl = experiment.inputFolder + File.separator + "input";
+			System.out.println("Reading from database at: " + DatabaseUtils.databaseInputUrl);
 		}
 		
 		if (saveExperimentOnDatabase) {

--- a/microsim-core/src/main/java/microsim/data/ExperimentManager.java
+++ b/microsim-core/src/main/java/microsim/data/ExperimentManager.java
@@ -176,8 +176,7 @@ public class ExperimentManager {
 			}
 		}
 		else{
-//			 DatabaseUtils.databaseInputUrl = experiment.inputFolder + File.separator + "input";
-			System.out.println("Reading from database at: " + DatabaseUtils.databaseInputUrl);
+			 DatabaseUtils.databaseInputUrl = experiment.inputFolder + File.separator + "input";
 		}
 		
 		if (saveExperimentOnDatabase) {

--- a/microsim-core/src/main/java/microsim/data/db/Experiment.java
+++ b/microsim-core/src/main/java/microsim/data/db/Experiment.java
@@ -57,7 +57,8 @@ public class Experiment {
 			SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMddHHmmss");
 			runId = sdf.format(new Date());
 		}
-		return outputRootFolder + File.separatorChar + runId;		
+		// multiRunId represents the seed of this run
+		return outputRootFolder + File.separatorChar + runId + "_" + multiRunId;
 	}
 	
 }

--- a/microsim-core/src/main/java/microsim/engine/MultiRun.java
+++ b/microsim-core/src/main/java/microsim/engine/MultiRun.java
@@ -98,7 +98,12 @@ public abstract class MultiRun extends Thread implements EngineListener, Experim
 	public synchronized void run() {
 		while (toBeContinued) {
 			executionActive = true;
-			go();
+			try {
+				go();
+			} catch (Exception e) {
+				System.out.println("Run " + multiRunId + " failed");
+			}
+
 			while (executionActive)
 				try {
 					sleep(300);


### PR DESCRIPTION
Addition of `multiRunId` to end of folder - to uniquely identify outputs of simultaneous runs with different seeds (for parallel processing)