### PR TITLE
Test for multirunid and omit null from folder name

### DIFF
--- a/microsim-core/src/main/java/microsim/data/db/Experiment.java
+++ b/microsim-core/src/main/java/microsim/data/db/Experiment.java
@@ -58,7 +58,11 @@ public class Experiment {
 			runId = sdf.format(new Date());
 		}
 		// multiRunId represents the seed of this run
-		return outputRootFolder + File.separatorChar + runId + "_" + multiRunId;
+		if (multiRunId == null) {
+			return outputRootFolder + File.separatorChar + runId;
+		} else {
+			return outputRootFolder + File.separatorChar + runId + "_" + multiRunId;
+		}
 	}
 	
 }


### PR DESCRIPTION
This is one suggested route for removing the null values from the end of newly created output folders in the single-run scenario. It could be possible to pass the seed to the folder name but it seems complicated! This may be worth implementing as a stand-in to at least not break normal single simpath runs?

Do review this @pbronka and see if it suits. I'm happy to keep playing around with passing the `randomSeedIfFixed` variable somehow to the `Experiment` object if this seems worth having appended to single runs also (e.g. for records/comparability).