### PR TITLE
no IntelliJ support for 2.2.220

### DIFF
--- a/microsim-core/pom.xml
+++ b/microsim-core/pom.xml
@@ -139,7 +139,7 @@
 		<dependency>
 			<groupId>com.h2database</groupId>
 			<artifactId>h2</artifactId>
-			<version>2.2.220</version>
+			<version>2.1.214</version>
 		</dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
2.2.220 requires h2 driver 2.2 to work - this driver is not yet bundled with IntelliJ