### PR TITLE
Allow complete exit when run fails

### DIFF
--- a/microsim-core/src/main/java/microsim/engine/MultiRun.java
+++ b/microsim-core/src/main/java/microsim/engine/MultiRun.java
@@ -101,7 +101,7 @@ public abstract class MultiRun extends Thread implements EngineListener, Experim
 			try {
 				go();
 			} catch (Exception e) {
-				System.out.println("Run failed");
+				System.out.println("Run failed: " + e.getMessage());
 				System.exit(0);
 			}
 

--- a/microsim-core/src/main/java/microsim/engine/MultiRun.java
+++ b/microsim-core/src/main/java/microsim/engine/MultiRun.java
@@ -101,7 +101,8 @@ public abstract class MultiRun extends Thread implements EngineListener, Experim
 			try {
 				go();
 			} catch (Exception e) {
-				System.out.println("Run " + multiRunId + " failed");
+				System.out.println("Run failed");
+				System.exit(0);
 			}
 
 			while (executionActive)

--- a/microsim-core/src/main/java/microsim/engine/MultiRun.java
+++ b/microsim-core/src/main/java/microsim/engine/MultiRun.java
@@ -102,7 +102,7 @@ public abstract class MultiRun extends Thread implements EngineListener, Experim
 				go();
 			} catch (Exception e) {
 				System.out.println("Run failed: " + e.getMessage());
-				System.exit(0);
+				System.exit(1);
 			}
 
 			while (executionActive)


### PR DESCRIPTION
Fixing an error I introduced a while ago (me again, sorry!). Catching the error produced during a run keeps the multirun going. This should exit after reporting the error. Thanks @pbronka @justin-ven 