### PR TITLE
Allow `intputFolder` and `outputRootFolder` to be edited by reflection

### DIFF
--- a/microsim-core/src/main/java/microsim/data/db/Experiment.java
+++ b/microsim-core/src/main/java/microsim/data/db/Experiment.java
@@ -47,10 +47,10 @@ public class Experiment {
 	public List<ExperimentParameter> parameters;
 	
 	@Transient
-	public String inputFolder = "./input";
+	public static String inputFolder = "./input";
 	
 	@Transient
-	public String outputRootFolder = "./output";
+	public static String outputRootFolder = "./output";
 	
 	public String getOutputFolder() {
 		if (runId == null) {


### PR DESCRIPTION
Setting these as `static` allows them to be edited using reflection from SimPaths calls:

	@Transient
	public static String inputFolder = "./input";
	
	@Transient
	public static String outputRootFolder = "./output";

e.g.:

	Field inputDir = Experiment.class.getDeclaredField("inputFolder");
	inputDir.setAccessible(true);
	inputDir.set(null, root_dir + File.separator + "input");
	inputDir.setAccessible(false);

can set the input folder and output folder according to new `root_dir` argument in [SimPathsMultiRun](https://github.com/centreformicrosimulation/SimPaths/blob/main/src/main/java/simpaths/experiment/SimPathsMultiRun.java).

I don't think this breaks or changes anything else @pbronka @justin-ven? A minor suggested tweak as I'm simultaneously working on a SimPaths possibility for specifying an input/output folder (for potential tweaks for batch runs).