### PR TITLE
PanelEntityKey extended and reduced storage of input parameters

### DIFF
--- a/microsim-core/pom.xml
+++ b/microsim-core/pom.xml
@@ -6,7 +6,7 @@
 	</properties>
 	<groupId>com.github.jasmineRepo</groupId>
 	<artifactId>JAS-mine-core</artifactId>
-	<version>4.3.7</version>
+	<version>4.3.8</version>
 	<build>
 		<plugins>
 			<plugin>

--- a/microsim-core/src/main/java/microsim/data/ExperimentManager.java
+++ b/microsim-core/src/main/java/microsim/data/ExperimentManager.java
@@ -171,7 +171,8 @@ public class ExperimentManager {
 				String[] files = inputDir.list();
 				for (String file : files) {
 //					if (! file.equals("input.odb") && ! file.startsWith("."))
-					if (! file.startsWith(".")) {
+					//if (! file.startsWith(".")) {
+					if (file.endsWith(".xlsx") || file.endsWith(".xls") || file.endsWith(".db")) {
 						log.debug("Copying " + file + " to output folder");
 						copy(inputDir + File.separator + file, outFolder);
 					}

--- a/microsim-core/src/main/java/microsim/data/db/PanelEntityKey.java
+++ b/microsim-core/src/main/java/microsim/data/db/PanelEntityKey.java
@@ -19,6 +19,10 @@ public class PanelEntityKey implements Serializable {
 	@Column(name="simulation_run")
 	private long simulationRun;
 
+	@Column(name="working_id")
+	private long workingId = 0L;
+
+
 	public PanelEntityKey() {
 		super();
 	}
@@ -51,5 +55,8 @@ public class PanelEntityKey implements Serializable {
 	public void setSimulationRun(Long simulationRun) {
 		this.simulationRun = simulationRun;
 	}
-		
+
+	public long getWorkingId() { return workingId; }
+
+	public void setWorkingId(long workingId) { this.workingId = workingId; }
 }


### PR DESCRIPTION
Extension to PanelEntityKey allows for a "workingId", which is useful for retrieving related simulations from a relational database. Saved data for simulation "input" limited to excel files and database