### PR TITLE
Bugfix/fix output folder again

### DIFF
--- a/microsim-core/pom.xml
+++ b/microsim-core/pom.xml
@@ -6,7 +6,7 @@
 	</properties>
 	<groupId>com.github.jasmineRepo</groupId>
 	<artifactId>JAS-mine-core</artifactId>
-	<version>4.3.24</version>
+	<version>4.3.25</version>
 	<build>
 		<plugins>
 			<plugin>

--- a/microsim-core/src/main/java/microsim/data/ExperimentManager.java
+++ b/microsim-core/src/main/java/microsim/data/ExperimentManager.java
@@ -155,6 +155,8 @@ public class ExperimentManager {
 	
 	public Experiment setupExperiment(Experiment experiment, Object... models) throws Exception {
 		final String outFolder = experiment.getOutputFolder() + File.separator + "input";
+
+		ExportCSV.directory = experiment.getOutputFolder() + File.separator + "csv";
 		
 		log.debug("Setting up experiment " + experiment.runId);
 		

--- a/microsim-core/src/main/java/microsim/data/ExportCSV.java
+++ b/microsim-core/src/main/java/microsim/data/ExportCSV.java
@@ -36,7 +36,7 @@ public class ExportCSV {
 	//Fields for exporting tables to output .csv files 
 	final static String newLine = "\n";
 	final static String delimiter = ","; 
-	final static String directory = SimulationEngine.getInstance().getCurrentExperiment().getOutputFolder() + File.separator + "csv";
+	public static String directory = null;
 	
 	
 	private Set<String> fieldsForExport;
@@ -58,8 +58,12 @@ public class ExportCSV {
 	 *  
 	 */
 	public ExportCSV(Object target) {
-        try { 
-        	
+        try {
+
+			if (directory == null) {
+				directory = SimulationEngine.getInstance().getCurrentExperiment().getOutputFolder() + File.separator + "csv";
+			}
+
         	Object obj;
         	
         	//Decide which 'mode' depending on whether the target is a single object or a collection of objects


### PR DESCRIPTION
# What

The output folder was still seeming to create a second output folder part way through setup through the `ExportCSV` method. This should create one folder and stick to it permanently.