### PR TITLE
Enable all compiler lints, solve low-hanging fruits

### DIFF
--- a/microsim-core/pom.xml
+++ b/microsim-core/pom.xml
@@ -2,6 +2,7 @@
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <properties>
+    <maven.compiler.release>17</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
   <groupId>com.github.jasmineRepo</groupId>
@@ -10,14 +11,13 @@
   <build>
     <plugins>
       <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <version>3.10.1</version>
-            <configuration> <!-- Compile java 17 compatible bytecode -->
-              <source>17</source>
-              <target>17</target>
-            </configuration>
-          </plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.15.0</version>
+        <configuration>
+          <compilerArgument>-Xlint:all</compilerArgument>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>

--- a/microsim-core/src/main/java/microsim/alignment/multiple/LogitScalingWeightedAlignment.java
+++ b/microsim-core/src/main/java/microsim/alignment/multiple/LogitScalingWeightedAlignment.java
@@ -182,7 +182,7 @@ public class LogitScalingWeightedAlignment<T extends Weight> extends AbstractMul
 		
 		if( (error >= allowedError) && enableWarnings) {
 			System.out.println("WARNING: The LogitScalingWeightedAlignment.align() method terminated with an error of " 
-					+ (error/(double)total) + ", which has a greater magnitude than the precision bounds of +/-" + precision + ".  The size of "
+					+ (error/total) + ", which has a greater magnitude than the precision bounds of +/-" + precision + ".  The size of "
 					+ " the filtered agent collection is " + n + " and the number of iterations was  " + count + ".  Check the results of the Logit Scaling Weighted alignment to ensure that "
 					+ "alignment is good enough for the purpose in question, or consider increasing the maximum number of iterations "
 					+ "or the precision!");

--- a/microsim-core/src/main/java/microsim/alignment/outcome/ResamplingWeightedAlignment.java
+++ b/microsim-core/src/main/java/microsim/alignment/outcome/ResamplingWeightedAlignment.java
@@ -277,7 +277,7 @@ public class ResamplingWeightedAlignment<T extends EventListener & Weight> exten
 							+ "per object to be aligned) and has terminated.  Alignment may have "
 							+ "failed.  The difference between the population in the system with the "
 							+ "desired outcome and the target number is " + delta + " (" 
-							+ (delta*100./((double)targetNumber)) + " percent).  If this is too large, check "
+							+ (delta*100./targetNumber) + " percent).  If this is too large, check "
 							+ "the resampling method and the subset of population to understand why "
 							+ "not enough of the population are able to change their outcomes.");
 			System.out.println(Arrays.toString(Thread.currentThread().getStackTrace()));

--- a/microsim-core/src/main/java/microsim/alignment/probability/LogitScalingBinaryAlignment.java
+++ b/microsim-core/src/main/java/microsim/alignment/probability/LogitScalingBinaryAlignment.java
@@ -3,8 +3,6 @@ package microsim.alignment.probability;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import microsim.alignment.probability.AbstractProbabilityAlignment;
-import microsim.alignment.probability.AlignmentProbabilityClosure;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.Predicate;

--- a/microsim-core/src/main/java/microsim/alignment/probability/SBDAlignment.java
+++ b/microsim-core/src/main/java/microsim/alignment/probability/SBDAlignment.java
@@ -32,7 +32,7 @@ public class SBDAlignment<T> extends AbstractProbabilityAlignment<T> {
 			T agent = list.get(i); 
 			double p = closure.getProbability(agent);
 			double r = SimulationEngine.getRnd().nextDouble();
-			map.put(agent, new Double(p-r));
+			map.put(agent, p-r);
 		}
 		map = sortByComparator(map, false); // true for ascending order.			//Returns a LinkedHashMap, that maintains the order of insertion.
 		

--- a/microsim-core/src/main/java/microsim/alignment/probability/SBDLAlignment.java
+++ b/microsim-core/src/main/java/microsim/alignment/probability/SBDLAlignment.java
@@ -32,7 +32,7 @@ public class SBDLAlignment<T> extends AbstractProbabilityAlignment<T> {
 			T agent = list.get(i);
 			double p = closure.getProbability(agent);
 			double r = SimulationEngine.getRnd().nextDouble();		
-			map.put(agent, new Double(Math.log(1/r-1)+Math.log(p/(1-p))));
+			map.put(agent, Math.log(1/r-1)+Math.log(p/(1-p)));
 		}
 		map = sortByComparator(map, false); // true for ascending order			//Returns a LinkedHashMap, that maintains the order of insertion.
 		int i = 0;

--- a/microsim-core/src/main/java/microsim/data/ExperimentManager.java
+++ b/microsim-core/src/main/java/microsim/data/ExperimentManager.java
@@ -3,20 +3,13 @@ package microsim.data;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
-import java.io.IOException;
 import java.nio.channels.FileChannel;
-import java.nio.charset.Charset;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.sql.Date;
 
 import microsim.data.db.DatabaseUtils;
 import microsim.data.db.Experiment;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.StringEscapeUtils;
 import org.apache.log4j.Logger;
 
 /**

--- a/microsim-core/src/main/java/microsim/data/db/DatabaseUtils.java
+++ b/microsim-core/src/main/java/microsim/data/db/DatabaseUtils.java
@@ -121,14 +121,14 @@ public class DatabaseUtils {
 
 	public static void snap(Object target) throws Exception {
 		snap(DatabaseUtils.getOutEntityManger(), 
-				new Long(SimulationEngine.getInstance().getCurrentRunNumber()),
+				Long.valueOf(SimulationEngine.getInstance().getCurrentRunNumber()),
 				SimulationEngine.getInstance().getTime(),
 				target);
 	}
 	
 	public static void snap(Collection<?> targetCollection) throws Exception {
 		snap(DatabaseUtils.getOutEntityManger(), 
-				new Long(SimulationEngine.getInstance().getCurrentRunNumber()),
+				Long.valueOf(SimulationEngine.getInstance().getCurrentRunNumber()),
 				SimulationEngine.getInstance().getTime(),
 				targetCollection);
 	}

--- a/microsim-core/src/main/java/microsim/data/db/Experiment.java
+++ b/microsim-core/src/main/java/microsim/data/db/Experiment.java
@@ -3,9 +3,7 @@ package microsim.data.db;
 import java.io.File;
 import java.text.SimpleDateFormat;
 import java.util.Date;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;

--- a/microsim-core/src/main/java/microsim/data/db/space/SpaceEntityPersister.java
+++ b/microsim-core/src/main/java/microsim/data/db/space/SpaceEntityPersister.java
@@ -19,8 +19,8 @@ public class SpaceEntityPersister {
 		try {
 			for (int x = 0; x < space.getXSize(); x++) {
 				for (int y = 0; y < space.getYSize(); y++) {
-					final IIntSpaceEntity entity = entityClass.newInstance();
-					entity.setSimulationRun(new Long(SimulationEngine.getInstance().getCurrentRunNumber()));
+					final IIntSpaceEntity entity = entityClass.getDeclaredConstructor().newInstance();
+					entity.setSimulationRun(Long.valueOf(SimulationEngine.getInstance().getCurrentRunNumber()));
 					entity.setSimulationTime(SimulationEngine.getInstance().getTime());
 					entity.setX(x);
 					entity.setY(y);
@@ -48,8 +48,8 @@ public class SpaceEntityPersister {
 		try {
 			for (int x = 0; x < space.getXSize(); x++) {
 				for (int y = 0; y < space.getYSize(); y++) {
-					final IIntSpaceEntity entity = entityClass.newInstance();
-					entity.setSimulationRun(new Long(SimulationEngine.getInstance().getCurrentRunNumber()));
+					final IIntSpaceEntity entity = entityClass.getDeclaredConstructor().newInstance();
+					entity.setSimulationRun(Long.valueOf(SimulationEngine.getInstance().getCurrentRunNumber()));
 					entity.setSimulationTime(SimulationEngine.getInstance().getTime());
 					entity.setX(x);
 					entity.setY(y);

--- a/microsim-core/src/main/java/microsim/data/excel/ExcelAssistant.java
+++ b/microsim-core/src/main/java/microsim/data/excel/ExcelAssistant.java
@@ -7,7 +7,6 @@ import java.io.IOException;
 import microsim.data.MultiKeyCoefficientMap;
 
 import org.apache.poi.EncryptedDocumentException;
-import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
 import org.apache.poi.ss.usermodel.*;
 
 

--- a/microsim-core/src/main/java/microsim/engine/MultiRun.java
+++ b/microsim-core/src/main/java/microsim/engine/MultiRun.java
@@ -163,7 +163,7 @@ public abstract class MultiRun extends Thread implements EngineListener, Experim
 				for (MultiRunListener listener : multiRunListeners) 
 					listener.afterSimulationCompleted(engine);
 			
-			this.yield();
+			Thread.yield();
 			toBeContinued = nextModel();
 			engine.disposeModels();
 			executionActive = false;

--- a/microsim-core/src/main/java/microsim/engine/SimulationEngine.java
+++ b/microsim-core/src/main/java/microsim/engine/SimulationEngine.java
@@ -570,7 +570,7 @@ public class SimulationEngine extends Thread {
 
 		eventQueue.step();
 		notifySimulationListeners(SystemEventType.Step);
-		this.yield();
+		Thread.yield();
 	}
 
 	protected synchronized void notifySimulationListeners(SystemEventType event) {
@@ -613,7 +613,7 @@ public class SimulationEngine extends Thread {
 				}
 			// this is now called in step() method.
 			else
-				this.yield();
+				Thread.yield();
 		}
 
 	}

--- a/microsim-core/src/main/java/microsim/engine/SimulationEngine.java
+++ b/microsim-core/src/main/java/microsim/engine/SimulationEngine.java
@@ -447,7 +447,7 @@ public class SimulationEngine extends Thread {
 		// Get models' class type and dispose
 		Class<?>[] cls = new Class[models.size()];
 		for (int i = 0; i < models.size(); i++) {
-			SimulationManager model = (SimulationManager) models.get(i);
+			SimulationManager model = models.get(i);
 			cls[i] = model.getClass();
 			model.dispose();
 		}

--- a/microsim-core/src/main/java/microsim/engine/SimulationEngine.java
+++ b/microsim-core/src/main/java/microsim/engine/SimulationEngine.java
@@ -1,5 +1,6 @@
 package microsim.engine;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -267,10 +268,9 @@ public class SimulationEngine extends Thread {
 	public void setup() {
 		if (builderClass != null)
 			try {
-				((ExperimentBuilder) builderClass.newInstance()).buildExperiment(this);
-			} catch (InstantiationException e) {
-				log.error(e.getMessage());
-			} catch (IllegalAccessException e) {
+				((ExperimentBuilder) builderClass.getDeclaredConstructor().newInstance()).buildExperiment(this);
+			} catch (InstantiationException | IllegalAccessException | NoSuchMethodException
+                    | InvocationTargetException e) {
 				log.error(e.getMessage());
 			}
 		else if (experimentBuilder != null)
@@ -388,12 +388,12 @@ public class SimulationEngine extends Thread {
 		return simulationManager;
 	}
 
-	public SimulationManager addSimulationManager(String managerClassName) throws InstantiationException, IllegalAccessException, ClassNotFoundException {
+	public SimulationManager addSimulationManager(String managerClassName) throws InstantiationException, IllegalAccessException, ClassNotFoundException, NoSuchMethodException, InvocationTargetException {
 		SimulationManager simulationManager = null;
 		if (classLoader != null)
-			simulationManager = (SimulationManager) classLoader.loadClass(managerClassName).newInstance();
+			simulationManager = (SimulationManager) classLoader.loadClass(managerClassName).getDeclaredConstructor().newInstance();
 		else
-			simulationManager = (SimulationManager) Class.forName(managerClassName).newInstance();
+			simulationManager = (SimulationManager) Class.forName(managerClassName).getDeclaredConstructor().newInstance();
 		return addSimulationManager(simulationManager);
 	}
 	

--- a/microsim-core/src/main/java/microsim/matching/GlobalMatching.java
+++ b/microsim-core/src/main/java/microsim/matching/GlobalMatching.java
@@ -1,7 +1,5 @@
 package microsim.matching;
-//package microsim.matching;
 
-import microsim.statistics.regression.RegressionUtils;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.Predicate;
 import org.apache.commons.math3.util.Pair;

--- a/microsim-core/src/main/java/microsim/matching/GlobalMatchingPair.java
+++ b/microsim-core/src/main/java/microsim/matching/GlobalMatchingPair.java
@@ -1,7 +1,5 @@
 package microsim.matching;
 
-import org.apache.commons.math3.util.Pair;
-
 public class GlobalMatchingPair<T> {
 
     T agent1;

--- a/microsim-core/src/main/java/microsim/space/DoubleSpace.java
+++ b/microsim-core/src/main/java/microsim/space/DoubleSpace.java
@@ -59,7 +59,7 @@ public class DoubleSpace extends AbstractSpace<Double>
    *  @return The Double wrapper for value stored at x,y position of the grid. */
   public Double get(int x, int y)
   {
-    return new Double(m[at(x, y)]);
+    return m[at(x, y)];
   }
 
   /** Return the value at given position.

--- a/microsim-core/src/main/java/microsim/space/IntSpace.java
+++ b/microsim-core/src/main/java/microsim/space/IntSpace.java
@@ -89,7 +89,7 @@ public class IntSpace extends AbstractSpace<Integer> {
 	 * @return The Integer wrapper for value stored at x,y position of the grid.
 	 */
 	public Integer get(int x, int y) {
-		return new Integer(m[at(x, y)]);
+		return m[at(x, y)];
 	}
 
 	/**

--- a/microsim-core/src/main/java/microsim/space/MultiObjectSpace.java
+++ b/microsim-core/src/main/java/microsim/space/MultiObjectSpace.java
@@ -117,6 +117,7 @@ public class MultiObjectSpace extends DenseObjectSpace {
 	 * @deprecated Its name has been changed in countObjectsAt Alias for
 	 *             countObjectsAt
 	 * */
+    @Deprecated
 	public int countAt(int x, int y) {
 		return countObjectsAt(x, y);
 	}

--- a/microsim-core/src/main/java/microsim/statistics/regression/OrderedRegression.java
+++ b/microsim-core/src/main/java/microsim/statistics/regression/OrderedRegression.java
@@ -6,8 +6,6 @@ import org.apache.logging.log4j.util.Strings;
 
 import java.util.*;
 
-import static microsim.statistics.regression.RegressionUtils.populateMultinomialCoefficientMap;
-
 
 /**
  * Ordered Discrete Variable Models.

--- a/microsim-core/src/main/java/microsim/statistics/regression/ProbabilityCalculator.java
+++ b/microsim-core/src/main/java/microsim/statistics/regression/ProbabilityCalculator.java
@@ -4,10 +4,6 @@ import cern.jet.random.Normal;
 import cern.jet.random.engine.MersenneTwister;
 import microsim.data.MultiKeyCoefficientMap;
 import microsim.statistics.IDoubleSource;
-import org.apache.commons.math3.distribution.NormalDistribution;
-
-import java.util.HashMap;
-import java.util.Map;
 
 
 /*****************************************************************

--- a/microsim-core/src/main/java/microsim/statistics/regression/RegressionUtils.java
+++ b/microsim-core/src/main/java/microsim/statistics/regression/RegressionUtils.java
@@ -4,7 +4,6 @@ import java.util.*;
 
 import microsim.data.MultiKeyCoefficientMap;
 import microsim.engine.SimulationEngine;
-import microsim.statistics.regression.RegressionColumnNames;
 
 import org.apache.commons.collections4.MapIterator;
 import org.apache.commons.collections4.keyvalue.MultiKey;


### PR DESCRIPTION
This enables compiler lints. This PR also resolves the ones that were immediately obvious to solve (mainly redundant casts and deprecation warnings).

The remaining lints mainly concern:

- ambiguous calls to varargs functions where an explicit cast to `Object[]` or `Object` will be necessary;
- raw types, i.e. generics that are left unspecified leading to unchecked operations;
- a few possible "this" escapes that will be worth investigating.