### PR TITLE
add action to publish on github package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,23 @@
+name: publish to github packages
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          distribution: "temurin"
+          java-version: "25"
+          cache: "maven"
+          cache-dependency-path: "pom.xml"
+      - run: mvn versions:set -DnewVersion=$(git rev-parse HEAD)
+      - run: mvn --batch-mode deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,14 @@
     </dependencies>
   </dependencyManagement>
 
+  <distributionManagement>
+    <repository>
+      <id>github</id>
+      <name>GitHub Packages</name>
+      <url>https://maven.pkg.github.com/jasmineRepo/JAS-mine-core</url>
+    </repository>
+  </distributionManagement>
+
   <build>
     <plugins>
       <plugin>


### PR DESCRIPTION
There seems to be issues with `jitpack.io` (where we currently publish the JAS-mine-core` package), in particular related to setting the version of Java itself (e.g. https://github.com/jitpack/jitpack.io/issues/4260 which has been longstanding, so jitpack seems unfortunately poorly maintained). Not having a hand on the package build is going to be long term headache. One possible option would be to use the Github repository instead where we can control the build via an action.

This PR adds an action to publish the package to the maven github repository. Note that for now, it is only triggered manually, and changes the version to the current commit (this is to mimic what I'm using jitpack for in https://github.com/simpaths/SimPaths/pull/479). My hope is to be able to use that action to reliably be able to run the SimPaths tests against an arbitrary development version of jasmine.

Note: because this is a manually triggered action, I cannot use it until it is merged. Since this PR is very self-contained and easily revertible if we then decide it isn't the direction to go, I'll exceptionally merge this PR right away so I can test whether the action works.