### PR TITLE
Resolve most deprecation warnings

### DIFF
--- a/src/main/java/microsim/alignment/multiple/AbstractMultiProbabilityAlignment.java
+++ b/src/main/java/microsim/alignment/multiple/AbstractMultiProbabilityAlignment.java
@@ -1,7 +1,7 @@
 package microsim.alignment.multiple;
 
 import java.util.Collection;
-import org.apache.commons.collections4.Predicate;
+import java.util.function.Predicate;
 
 /**
  * Multiple choice alignment methods, where there are in general many

--- a/src/main/java/microsim/alignment/multiple/LogitScalingAlignment.java
+++ b/src/main/java/microsim/alignment/multiple/LogitScalingAlignment.java
@@ -3,8 +3,9 @@ package microsim.alignment.multiple;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.function.Predicate;
+
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.collections4.Predicate;
 
 /**
  * Logit Scaling alignment (as introduced by P. Stephensen in International
@@ -137,9 +138,9 @@ public class LogitScalingAlignment<T> extends AbstractMultiProbabilityAlignment<
                     "precision in LogitScalingAlignment.align() method must be greater than 0");
         }
 
-        List<T> list = new ArrayList<T>();
+        var list = new ArrayList<T>();
         if (filter != null)
-            CollectionUtils.select(agents, filter, list);
+            agents.stream().filter(filter).forEachOrdered(list::add);
         else
             list.addAll(agents);
 

--- a/src/main/java/microsim/alignment/multiple/LogitScalingWeightedAlignment.java
+++ b/src/main/java/microsim/alignment/multiple/LogitScalingWeightedAlignment.java
@@ -2,10 +2,7 @@ package microsim.alignment.multiple;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
-
-import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.collections4.Predicate;
+import java.util.function.Predicate;
 
 import microsim.agent.Weight;
 
@@ -150,9 +147,9 @@ public class LogitScalingWeightedAlignment<T extends Weight> extends AbstractMul
                     "precision in LogitScalingAlignment.align() method must be greater than 0");
         }
 
-        List<T> list = new ArrayList<T>();
+        var list = new ArrayList<T>();
         if (filter != null)
-            CollectionUtils.select(agents, filter, list);
+            agents.stream().filter(filter).forEachOrdered(list::add);
         else
             list.addAll(agents);
 

--- a/src/main/java/microsim/alignment/outcome/AbstractOutcomeAlignment.java
+++ b/src/main/java/microsim/alignment/outcome/AbstractOutcomeAlignment.java
@@ -1,7 +1,7 @@
 package microsim.alignment.outcome;
 
 import java.util.Collection;
-import org.apache.commons.collections4.Predicate;
+import java.util.function.Predicate;
 
 /**
  * 

--- a/src/main/java/microsim/alignment/outcome/ResamplingAlignment.java
+++ b/src/main/java/microsim/alignment/outcome/ResamplingAlignment.java
@@ -4,13 +4,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
+import java.util.function.Predicate;
 
 import microsim.engine.SimulationEngine;
 import microsim.event.EventListener;
-
-import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.collections4.Predicate;
 
 /**
  * Align the population by resampling. This involves picking an agent from the
@@ -111,9 +108,9 @@ public class ResamplingAlignment<T extends EventListener> extends AbstractOutcom
             throw new IllegalArgumentException("ResamplingAlignment targetShare is negative!  This is impossible.");
         }
 
-        List<T> list = new ArrayList<T>();
+        var list = new ArrayList<T>();
         if (filter != null)
-            CollectionUtils.select(agents, filter, list);
+            agents.stream().filter(filter).forEachOrdered(list::add);
         else
             list.addAll(agents);
 
@@ -290,9 +287,9 @@ public class ResamplingAlignment<T extends EventListener> extends AbstractOutcom
                     "ResamplingAlignment targetNumber is negative!  This is impossible to reach.");
         }
 
-        List<T> list = new ArrayList<T>();
+        var list = new ArrayList<T>();
         if (filter != null)
-            CollectionUtils.select(agents, filter, list);
+            agents.stream().filter(filter).forEachOrdered(list::add);
         else
             list.addAll(agents);
 

--- a/src/main/java/microsim/alignment/outcome/ResamplingWeightedAlignment.java
+++ b/src/main/java/microsim/alignment/outcome/ResamplingWeightedAlignment.java
@@ -6,14 +6,12 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.function.Predicate;
 
 import microsim.agent.Weight;
 import microsim.engine.SimulationEngine;
 import microsim.event.EventListener;
 import microsim.statistics.regression.RegressionUtils;
-
-import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.collections4.Predicate;
 
 /**
  * Align the population by weighted resampling. This involves picking an agent
@@ -123,9 +121,9 @@ public class ResamplingWeightedAlignment<T extends EventListener & Weight> exten
                     "ResamplingWeightedAlignment targetShare is negative!  This is impossible to reach.");
         }
 
-        List<T> list = new ArrayList<T>();
+        var list = new ArrayList<T>();
         if (filter != null)
-            CollectionUtils.select(agents, filter, list);
+            agents.stream().filter(filter).forEachOrdered(list::add);
         else
             list.addAll(agents);
 
@@ -223,9 +221,9 @@ public class ResamplingWeightedAlignment<T extends EventListener & Weight> exten
                     "ResamplingWeightedAlignment targetNumber is negative!  This is impossible to reach.");
         }
 
-        List<T> list = new ArrayList<T>();
+        var list = new ArrayList<T>();
         if (filter != null)
-            CollectionUtils.select(agents, filter, list);
+            agents.stream().filter(filter).forEachOrdered(list::add);
         else
             list.addAll(agents);
 

--- a/src/main/java/microsim/alignment/probability/AbstractProbabilityAlignment.java
+++ b/src/main/java/microsim/alignment/probability/AbstractProbabilityAlignment.java
@@ -8,8 +8,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-
-import org.apache.commons.collections4.Predicate;
+import java.util.function.Predicate;
 
 /**
  * Abstract class for BINARY PROBABILITY alignment methods (for Binary

--- a/src/main/java/microsim/alignment/probability/LogitScalingBinaryAlignment.java
+++ b/src/main/java/microsim/alignment/probability/LogitScalingBinaryAlignment.java
@@ -2,10 +2,7 @@ package microsim.alignment.probability;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
-
-import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.collections4.Predicate;
+import java.util.function.Predicate;
 
 /**
  * Logit Scaling alignment (as introduced by P. Stephensen in International
@@ -128,9 +125,9 @@ public class LogitScalingBinaryAlignment<T> extends AbstractProbabilityAlignment
                     "precision in LogitScalingBinaryAlignment.align() method must be greater than 0");
         }
 
-        List<T> list = new ArrayList<T>();
+        var list = new ArrayList<T>();
         if (filter != null)
-            CollectionUtils.select(agents, filter, list);
+            agents.stream().filter(filter).forEachOrdered(list::add);
         else
             list.addAll(agents);
 

--- a/src/main/java/microsim/alignment/probability/LogitScalingBinaryWeightedAlignment.java
+++ b/src/main/java/microsim/alignment/probability/LogitScalingBinaryWeightedAlignment.java
@@ -2,12 +2,9 @@ package microsim.alignment.probability;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
+import java.util.function.Predicate;
 
 import microsim.agent.Weight;
-
-import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.collections4.Predicate;
 
 /**
  * Logit Scaling alignment (as introduced by P. Stephensen in International
@@ -139,9 +136,9 @@ public class LogitScalingBinaryWeightedAlignment<T extends Weight> extends Abstr
                     "precision in LogitScalingBinaryWeightedAlignment.align() method must be greater than 0");
         }
 
-        List<T> list = new ArrayList<T>();
+        var list = new ArrayList<T>();
         if (filter != null)
-            CollectionUtils.select(agents, filter, list);
+            agents.stream().filter(filter).forEachOrdered(list::add);
         else
             list.addAll(agents);
 

--- a/src/main/java/microsim/alignment/probability/MultiplicativeScalingAlignment.java
+++ b/src/main/java/microsim/alignment/probability/MultiplicativeScalingAlignment.java
@@ -2,10 +2,7 @@ package microsim.alignment.probability;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
-
-import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.collections4.Predicate;
+import java.util.function.Predicate;
 
 public class MultiplicativeScalingAlignment<T> extends AbstractProbabilityAlignment<T> {
 
@@ -16,9 +13,9 @@ public class MultiplicativeScalingAlignment<T> extends AbstractProbabilityAlignm
             throw new IllegalArgumentException("target probability must lie in [0,1]");
         }
 
-        List<T> list = new ArrayList<T>();
+        var list = new ArrayList<T>();
         if (filter != null)
-            CollectionUtils.select(agents, filter, list);
+            agents.stream().filter(filter).forEachOrdered(list::add);
         else
             list.addAll(agents);
 

--- a/src/main/java/microsim/alignment/probability/SBDAlignment.java
+++ b/src/main/java/microsim/alignment/probability/SBDAlignment.java
@@ -3,13 +3,10 @@ package microsim.alignment.probability;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 import microsim.engine.SimulationEngine;
-
-import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.collections4.Predicate;
 
 public class SBDAlignment<T> extends AbstractProbabilityAlignment<T> {
 
@@ -20,9 +17,9 @@ public class SBDAlignment<T> extends AbstractProbabilityAlignment<T> {
             throw new IllegalArgumentException("target probability must lie in [0,1]");
         }
 
-        List<T> list = new ArrayList<T>();
+        var list = new ArrayList<T>();
         if (filter != null)
-            CollectionUtils.select(agents, filter, list);
+            agents.stream().filter(filter).forEachOrdered(list::add);
         else
             list.addAll(agents);
 

--- a/src/main/java/microsim/alignment/probability/SBDLAlignment.java
+++ b/src/main/java/microsim/alignment/probability/SBDLAlignment.java
@@ -3,11 +3,8 @@ package microsim.alignment.probability;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-
-import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.collections4.Predicate;
+import java.util.function.Predicate;
 
 import microsim.engine.SimulationEngine;
 
@@ -20,9 +17,9 @@ public class SBDLAlignment<T> extends AbstractProbabilityAlignment<T> {
             throw new IllegalArgumentException("target probability must lie in [0,1]");
         }
 
-        List<T> list = new ArrayList<T>();
+        var list = new ArrayList<T>();
         if (filter != null)
-            CollectionUtils.select(agents, filter, list);
+            agents.stream().filter(filter).forEachOrdered(list::add);
         else
             list.addAll(agents);
 

--- a/src/main/java/microsim/alignment/probability/SidewalkAlignment.java
+++ b/src/main/java/microsim/alignment/probability/SidewalkAlignment.java
@@ -3,10 +3,7 @@ package microsim.alignment.probability;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
-
-import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.collections4.Predicate;
+import java.util.function.Predicate;
 
 import microsim.engine.SimulationEngine;
 
@@ -19,9 +16,9 @@ public class SidewalkAlignment<T> extends AbstractProbabilityAlignment<T> {
             throw new IllegalArgumentException("target probability must lie in [0,1]");
         }
 
-        List<T> list = new ArrayList<T>();
+        var list = new ArrayList<T>();
         if (filter != null)
-            CollectionUtils.select(agents, filter, list);
+            agents.stream().filter(filter).forEachOrdered(list::add);
         else
             list.addAll(agents);
 

--- a/src/main/java/microsim/collection/Aggregate.java
+++ b/src/main/java/microsim/collection/Aggregate.java
@@ -1,19 +1,16 @@
 package microsim.collection;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import org.apache.commons.collections4.Closure;
-import org.apache.commons.collections4.Predicate;
-import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.collections4.IterableUtils;
+import java.util.function.Consumer;
+import java.util.function.Predicate;
 
 public class Aggregate {
 
-    public static <T> void applyToFilter(Iterable<T> collection, Predicate<T> predicate, Closure<T> closure) {
-        final List<T> filtered = new ArrayList<T>();
-        CollectionUtils.select(collection, predicate, filtered);
-        IterableUtils.forEach(filtered, closure);
+    public static <T> void applyToFilter(Iterable<T> collection, Predicate<T> predicate, Consumer<T> closure) {
+        collection.forEach(item -> {
+            if (predicate.test(item)) {
+                closure.accept(item);
+            }
+        });
     }
 
 }

--- a/src/main/java/microsim/collection/AverageClosure.java
+++ b/src/main/java/microsim/collection/AverageClosure.java
@@ -1,8 +1,8 @@
 package microsim.collection;
 
-import org.apache.commons.collections4.Closure;
+import java.util.function.Consumer;
 
-public abstract class AverageClosure<T> implements Closure<T> {
+public abstract class AverageClosure<T> implements Consumer<T> {
 
     protected double sum = 0.0;
 

--- a/src/main/java/microsim/gui/plot/Weighted_HistogramDataset.java
+++ b/src/main/java/microsim/gui/plot/Weighted_HistogramDataset.java
@@ -195,8 +195,8 @@ public class Weighted_HistogramDataset extends AbstractIntervalXYDataset
         Map map = new LinkedHashMap();
         map.put("key", key);
         map.put("bins", binList);
-        map.put("values.length", new Integer(values.length));
-        map.put("bin width", new Double(binWidth));
+        map.put("values.length", values.length);
+        map.put("bin width", binWidth);
         this.list.add(map);
         fireDatasetChanged();
     }
@@ -348,7 +348,7 @@ public class Weighted_HistogramDataset extends AbstractIntervalXYDataset
         List bins = getBins(series);
         Weighted_HistogramBin bin = (Weighted_HistogramBin) bins.get(item);
         double x = (bin.getStartBoundary() + bin.getEndBoundary()) / 2.;
-        return new Double(x);
+        return x;
     }
 
     /**
@@ -372,11 +372,11 @@ public class Weighted_HistogramDataset extends AbstractIntervalXYDataset
         double binWidth = getBinWidth(series);
 
         if (this.type == HistogramType.FREQUENCY) {
-            return new Double(bin.getCount());
+            return bin.getCount();
         } else if (this.type == HistogramType.RELATIVE_FREQUENCY) {
-            return new Double(bin.getCount() / total);
+            return bin.getCount() / total;
         } else if (this.type == HistogramType.SCALE_AREA_TO_1) {
-            return new Double(bin.getCount() / (binWidth * total));
+            return bin.getCount() / (binWidth * total);
         } else { // pretty sure this shouldn't ever happen
             throw new IllegalStateException();
         }
@@ -398,7 +398,7 @@ public class Weighted_HistogramDataset extends AbstractIntervalXYDataset
     public Number getStartX(int series, int item) {
         List bins = getBins(series);
         Weighted_HistogramBin bin = (Weighted_HistogramBin) bins.get(item);
-        return new Double(bin.getStartBoundary());
+        return bin.getStartBoundary();
     }
 
     /**
@@ -417,7 +417,7 @@ public class Weighted_HistogramDataset extends AbstractIntervalXYDataset
     public Number getEndX(int series, int item) {
         List bins = getBins(series);
         Weighted_HistogramBin bin = (Weighted_HistogramBin) bins.get(item);
-        return new Double(bin.getEndBoundary());
+        return bin.getEndBoundary();
     }
 
     /**

--- a/src/main/java/microsim/gui/probe/MethodParameterDataModel.java
+++ b/src/main/java/microsim/gui/probe/MethodParameterDataModel.java
@@ -153,21 +153,21 @@ public class MethodParameterDataModel extends AbstractTableModel {
 
     private Object getWrapper(String s, String o) {
         if (s.equals(Integer.TYPE.getName()))
-            return new Integer(Integer.parseInt(o));
+            return Integer.parseInt(o);
         if (s.equals(Double.TYPE.getName()))
-            return new Double(Double.parseDouble(o));
+            return Double.parseDouble(o);
         if (s.equals(Boolean.TYPE.getName()))
-            return new Boolean(Boolean.valueOf(o).booleanValue());
+            return Boolean.valueOf(o);
         if (s.equals(Byte.TYPE.getName()))
-            return new Byte(Byte.parseByte(o));
+            return Byte.parseByte(o);
         if (s.equals(Character.TYPE.getName()))
-            return new Character(o.charAt(0));
+            return o.charAt(0);
         if (s.equals(Float.TYPE.getName()))
-            return new Float(Float.parseFloat(o));
+            return Float.parseFloat(o);
         if (s.equals(Long.TYPE.getName()))
-            return new Long(Long.parseLong(o));
+            return Long.parseLong(o);
         if (s.equals(Short.TYPE.getName()))
-            return new Short(Short.parseShort(o));
+            return Short.parseShort(o);
 
         return null;
     }

--- a/src/main/java/microsim/gui/probe/ProbeReflectionUtils.java
+++ b/src/main/java/microsim/gui/probe/ProbeReflectionUtils.java
@@ -130,7 +130,7 @@ public class ProbeReflectionUtils {
 
                 f = o.getClass().getDeclaredField("count");
                 f.setAccessible(true);
-                f.set(o, new Integer(ch.length));
+                f.set(o, ch.length);
 
                 return;
             }

--- a/src/main/java/microsim/gui/shell/AboutFrame.java
+++ b/src/main/java/microsim/gui/shell/AboutFrame.java
@@ -3,7 +3,7 @@ package microsim.gui.shell;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.awt.Toolkit;
-import java.io.BufferedInputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Enumeration;
 import java.util.Properties;
 
@@ -16,8 +16,6 @@ import javax.swing.JTabbedPane;
 import javax.swing.JTable;
 import javax.swing.JTextArea;
 import javax.swing.border.TitledBorder;
-
-import org.apache.commons.io.IOUtils;
 
 /**
  * The about frame of the JAS application.
@@ -130,10 +128,8 @@ public class AboutFrame extends JFrame {
 
     private String getLicence() {
         try {
-            final BufferedInputStream bis = new BufferedInputStream(
-                    AboutFrame.class.getResourceAsStream("/jasmine_license.txt"));
-            return IOUtils.toString(bis);
-
+            var bytes = AboutFrame.class.getResourceAsStream("/jasmine_license.txt").readAllBytes();
+            return new String(bytes, StandardCharsets.UTF_8);
         } catch (Exception e) {
             return "WARNING: No licence file found!";
         }

--- a/src/main/java/microsim/gui/shell/MicrosimShell.java
+++ b/src/main/java/microsim/gui/shell/MicrosimShell.java
@@ -214,8 +214,8 @@ public class MicrosimShell extends JFrame {
         });
         try {
             UIManager// .setLookAndFeel("com.jgoodies.looks.plastic.PlasticXPLookAndFeel");
-                    // .setLookAndFeel("com.jgoodies.looks.windows.WindowsLookAndFeel");
-                    // .setLookAndFeel("net.infonode.gui.laf.InfoNodeLookAndFeel");
+                     // .setLookAndFeel("com.jgoodies.looks.windows.WindowsLookAndFeel");
+                     // .setLookAndFeel("net.infonode.gui.laf.InfoNodeLookAndFeel");
                     .setLookAndFeel(new FlatLightLaf());
             SwingUtilities.updateComponentTreeUI(this);
         } catch (Exception e) {

--- a/src/main/java/microsim/gui/shell/MicrosimShell.java
+++ b/src/main/java/microsim/gui/shell/MicrosimShell.java
@@ -601,15 +601,15 @@ public class MicrosimShell extends JFrame {
         // }
 
         public void navigateWebSite() {
-            // String command, path = "http://jaslibrary.sourceforge.net";
-            String command, path = "http://www.jas-mine.net";
+            var path = "http://www.jas-mine.net";
+            ProcessBuilder cmd;
             if (System.getProperty("file.separator").equals("/"))
-                command = "netscape " + path;
+                cmd = new ProcessBuilder("netscape", path);
             else
-                command = "cmd /C start " + path;
+                cmd = new ProcessBuilder("cmd", "/C", "start", "path");
 
             try {
-                Runtime.getRuntime().exec(command);
+                cmd.start();
             } catch (Exception ex) {
             }
         }

--- a/src/main/java/microsim/gui/shell/MicrosimShell.java
+++ b/src/main/java/microsim/gui/shell/MicrosimShell.java
@@ -602,12 +602,9 @@ public class MicrosimShell extends JFrame {
 
         public void navigateWebSite() {
             var path = "https://www.microsimulation.ac.uk/jas-mine/";
-            ProcessBuilder cmd;
-            if (System.getProperty("file.separator").equals("/"))
-                cmd = new ProcessBuilder("netscape", path);
-            else
-                cmd = new ProcessBuilder("cmd", "/C", "start", "path");
-
+            var os = System.getProperty("os.name").toLowerCase();
+            var cmd = os.contains("win") ? new ProcessBuilder("cmd", "/C", "start", "path")
+                    : new ProcessBuilder("netscape", path);
             try {
                 cmd.start();
             } catch (Exception ex) {

--- a/src/main/java/microsim/gui/shell/MicrosimShell.java
+++ b/src/main/java/microsim/gui/shell/MicrosimShell.java
@@ -601,7 +601,7 @@ public class MicrosimShell extends JFrame {
         // }
 
         public void navigateWebSite() {
-            var path = "http://www.jas-mine.net";
+            var path = "https://www.microsimulation.ac.uk/jas-mine/";
             ProcessBuilder cmd;
             if (System.getProperty("file.separator").equals("/"))
                 cmd = new ProcessBuilder("netscape", path);

--- a/src/main/java/microsim/matching/GlobalMatching.java
+++ b/src/main/java/microsim/matching/GlobalMatching.java
@@ -1,10 +1,10 @@
 package microsim.matching;
 
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.collections4.Predicate;
 import org.apache.commons.math3.util.Pair;
 
 import java.util.*;
+import java.util.function.Predicate;
 
 /**
  * MATCHING CLASS BASED ON THE ITERATIVE RANDOM MATCHING CLASS
@@ -27,15 +27,15 @@ public class GlobalMatching<T> {
         LinkedHashSet<T> unmatchedCollection2 = new LinkedHashSet<T>();
         Pair<Set<T>, Set<T>> unmatched = new Pair<>(unmatchedCollection1, unmatchedCollection2);
 
-        Set<T> c1 = new HashSet<T>();
+        var c1 = new HashSet<T>();
         if (filter1 != null)
-            CollectionUtils.select(collection1, filter1, c1);
+            collection1.stream().filter(filter1).forEachOrdered(c1::add);
         else
             c1.addAll(collection1);
 
-        Set<T> c2 = new HashSet<T>();
+        var c2 = new HashSet<T>();
         if (filter2 != null)
-            CollectionUtils.select(collection2, filter2, c2);
+            collection2.stream().filter(filter2).forEachOrdered(c2::add);
         else
             c2.addAll(collection2);
 

--- a/src/main/java/microsim/matching/IterativeMatchingAlgorithm.java
+++ b/src/main/java/microsim/matching/IterativeMatchingAlgorithm.java
@@ -4,8 +4,8 @@ package microsim.matching;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.Set;
+import java.util.function.Predicate;
 
-import org.apache.commons.collections4.Predicate;
 import org.apache.commons.math3.util.Pair;
 
 public interface IterativeMatchingAlgorithm<T> {

--- a/src/main/java/microsim/matching/IterativeRandomMatching.java
+++ b/src/main/java/microsim/matching/IterativeRandomMatching.java
@@ -10,9 +10,9 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.collections4.Predicate;
 import org.apache.commons.math3.util.Pair;
 
 import microsim.engine.SimulationEngine;
@@ -30,9 +30,9 @@ public class IterativeRandomMatching<T> implements IterativeMatchingAlgorithm<T>
 
         // long numberMatchesMade = 0l;
 
-        List<T> c1 = new ArrayList<T>();
+        var c1 = new ArrayList<T>();
         if (filter1 != null)
-            CollectionUtils.select(collection1, filter1, c1);
+            collection1.stream().filter(filter1).forEachOrdered(c1::add);
         else
             c1.addAll(collection1);
 
@@ -48,9 +48,9 @@ public class IterativeRandomMatching<T> implements IterativeMatchingAlgorithm<T>
             }
         }
 
-        List<T> c2 = new ArrayList<T>();
+        var c2 = new ArrayList<T>();
         if (filter2 != null)
-            CollectionUtils.select(collection2, filter2, c2);
+            collection2.stream().filter(filter2).forEachOrdered(c2::add);
         else
             c2.addAll(collection2);
 

--- a/src/main/java/microsim/matching/IterativeSimpleMatching.java
+++ b/src/main/java/microsim/matching/IterativeSimpleMatching.java
@@ -9,7 +9,6 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.math3.util.Pair;

--- a/src/main/java/microsim/matching/IterativeSimpleMatching.java
+++ b/src/main/java/microsim/matching/IterativeSimpleMatching.java
@@ -8,9 +8,10 @@ import java.util.Comparator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.collections4.Predicate;
 import org.apache.commons.math3.util.Pair;
 
 import microsim.engine.SimulationEngine;
@@ -27,9 +28,9 @@ public class IterativeSimpleMatching<T> implements IterativeMatchingAlgorithm<T>
 
         // long numberMatchesMade = 0l;
 
-        List<T> c1 = new ArrayList<T>();
+        var c1 = new ArrayList<T>();
         if (filter1 != null)
-            CollectionUtils.select(collection1, filter1, c1);
+            collection1.stream().filter(filter1).forEachOrdered(c1::add);
         else
             c1.addAll(collection1);
 
@@ -45,9 +46,9 @@ public class IterativeSimpleMatching<T> implements IterativeMatchingAlgorithm<T>
             }
         }
 
-        List<T> c2 = new ArrayList<T>();
+        var c2 = new ArrayList<T>();
         if (filter2 != null)
-            CollectionUtils.select(collection2, filter2, c2);
+            collection2.stream().filter(filter2).forEachOrdered(c2::add);
         else
             c2.addAll(collection2);
 

--- a/src/main/java/microsim/matching/MatchingAlgorithm.java
+++ b/src/main/java/microsim/matching/MatchingAlgorithm.java
@@ -2,8 +2,7 @@ package microsim.matching;
 
 import java.util.Collection;
 import java.util.Comparator;
-
-import org.apache.commons.collections4.Predicate;
+import java.util.function.Predicate;
 
 public interface MatchingAlgorithm<T> {
 

--- a/src/main/java/microsim/matching/SimpleMatching.java
+++ b/src/main/java/microsim/matching/SimpleMatching.java
@@ -5,8 +5,9 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.function.Predicate;
+
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.collections4.Predicate;
 import org.apache.commons.math3.util.Pair;
 
 import microsim.engine.SimulationEngine;
@@ -19,9 +20,9 @@ public class SimpleMatching<T> implements MatchingAlgorithm<T> {
 
         long numberMatchesMade = 0l;
 
-        List<T> c1 = new ArrayList<T>();
+        var c1 = new ArrayList<T>();
         if (filter1 != null)
-            CollectionUtils.select(collection1, filter1, c1);
+            collection1.stream().filter(filter1).forEachOrdered(c1::add);
         else
             c1.addAll(collection1);
 
@@ -37,9 +38,9 @@ public class SimpleMatching<T> implements MatchingAlgorithm<T> {
             }
         }
 
-        List<T> c2 = new ArrayList<T>();
+        var c2 = new ArrayList<T>();
         if (filter2 != null)
-            CollectionUtils.select(collection2, filter2, c2);
+            collection2.stream().filter(filter2).forEachOrdered(c2::add);
         else
             c2.addAll(collection2);
 


### PR DESCRIPTION
The only remaining deprecation warnings are internal, due to the deprecated `ModelParameter` annotation.