### PR TITLE
matching: deprecate using static instances

### DIFF
--- a/src/main/java/microsim/matching/GlobalMatching.java
+++ b/src/main/java/microsim/matching/GlobalMatching.java
@@ -78,14 +78,11 @@ public class GlobalMatching<T> {
         return unmatched;
     }
 
-    private GlobalMatching() {
-
-    }
-
-    // FIXME: remove static instance
     private static GlobalMatching<?> globalMatching;
 
+    /// @deprecated use constructor to obtain an instance
     @SuppressWarnings("rawtypes")
+    @Deprecated(forRemoval = true)
     public static GlobalMatching getInstance() {
         if (globalMatching == null)
             globalMatching = new GlobalMatching<>();

--- a/src/main/java/microsim/matching/IterativeRandomMatching.java
+++ b/src/main/java/microsim/matching/IterativeRandomMatching.java
@@ -99,14 +99,11 @@ public class IterativeRandomMatching<T> implements IterativeMatchingAlgorithm<T>
         return unmatched;
     }
 
-    private IterativeRandomMatching() {
-
-    }
-
-    // FIXME: remove static instance
     private static IterativeRandomMatching<?> iterativeRandomMatching;
 
+    /// @deprecated use constructor to obtain an instance
     @SuppressWarnings("rawtypes")
+    @Deprecated(forRemoval = true)
     public static IterativeRandomMatching getInstance() {
         if (iterativeRandomMatching == null)
             iterativeRandomMatching = new IterativeRandomMatching<>();

--- a/src/main/java/microsim/matching/IterativeSimpleMatching.java
+++ b/src/main/java/microsim/matching/IterativeSimpleMatching.java
@@ -109,14 +109,11 @@ public class IterativeSimpleMatching<T> implements IterativeMatchingAlgorithm<T>
         return unmatched;
     }
 
-    private IterativeSimpleMatching() {
-
-    }
-
-    // FIXME: remove static instance
     private static IterativeSimpleMatching<?> iterativeMatching;
 
+    /// @deprecated use constructor to obtain an instance
     @SuppressWarnings("rawtypes")
+    @Deprecated(forRemoval = true)
     public static IterativeSimpleMatching getInstance() {
         if (iterativeMatching == null)
             iterativeMatching = new IterativeSimpleMatching<>();

--- a/src/main/java/microsim/matching/SimpleMatching.java
+++ b/src/main/java/microsim/matching/SimpleMatching.java
@@ -89,14 +89,11 @@ public class SimpleMatching<T> implements MatchingAlgorithm<T> {
         // return numberMatchesMade;
     }
 
-    private SimpleMatching() {
-
-    }
-
-    // FIXME: remove static instance
     private static SimpleMatching<?> simpleMatching;
 
+    /// @deprecated use constructor to obtain an instance
     @SuppressWarnings("rawtypes")
+    @Deprecated(forRemoval = true)
     public static SimpleMatching getInstance() {
         if (simpleMatching == null)
             simpleMatching = new SimpleMatching<>();


### PR DESCRIPTION
Static instances cannot leverage generic typing by construction. In this case, they are also unnecessary at these objects do not store state that should be retained between invocations.